### PR TITLE
Add iosxr_domain terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ module "iosxr" {
 |------|------|
 | [iosxr_banner.banner](https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/banner) | resource |
 | [iosxr_cdp.cdp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/cdp) | resource |
+| [iosxr_domain.domain](https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/domain) | resource |
 | [iosxr_hostname.hostname](https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/hostname) | resource |
 | [iosxr_interface.interface](https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/interface) | resource |
 | [iosxr_lldp.lldp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/lldp) | resource |

--- a/iosxr_domain.tf
+++ b/iosxr_domain.tf
@@ -1,0 +1,15 @@
+resource "iosxr_domain" "domain" {
+  for_each = { for device in local.devices : device.name => device if try(local.device_config[device.name].domain, null) != null || try(local.defaults.iosxr.configuration.domain, null) != null }
+  device   = each.value.name
+
+  name                    = try(local.device_config[each.value.name].domain.name, local.defaults.iosxr.configuration.domain.name, null)
+  domains                 = try(local.device_config[each.value.name].domain.domains, local.defaults.iosxr.configuration.domain.domains, null)
+  lookup_disable          = try(local.device_config[each.value.name].domain.lookup_disable, local.defaults.iosxr.configuration.domain.lookup_disable, null)
+  lookup_source_interface = try(local.device_config[each.value.name].domain.lookup_source_interface, local.defaults.iosxr.configuration.domain.lookup_source_interface, null)
+  name_servers            = try(local.device_config[each.value.name].domain.name_servers, local.defaults.iosxr.configuration.domain.name_servers, null)
+  ipv4_hosts              = try(local.device_config[each.value.name].domain.ipv4_hosts, local.defaults.iosxr.configuration.domain.ipv4_hosts, null)
+  ipv6_hosts              = try(local.device_config[each.value.name].domain.ipv6_hosts, local.defaults.iosxr.configuration.domain.ipv6_hosts, null)
+  multicast               = try(local.device_config[each.value.name].domain.multicast, local.defaults.iosxr.configuration.domain.multicast, null)
+  default_flows_disable   = try(local.device_config[each.value.name].domain.default_flows_disable, local.defaults.iosxr.configuration.domain.default_flows_disable, null)
+  delete_mode             = try(local.device_config[each.value.name].domain.delete_mode, local.defaults.iosxr.configuration.domain.delete_mode, null)
+}


### PR DESCRIPTION
  Add iosxr_domain terraform module

  - Implement domain resource module with all provider parameters
  - Support complex nested configurations (hosts, servers, domains)  
  - Auto-updated documentation via terraform-docs

  ## Proposed Changes
  Complete terraform module implementation for iosxr_domain resource including:
  - Domain name configuration
  - DNS name servers with priority ordering
  - Domain search lists with ordering
  - IPv4/IPv6 host mappings  
  - Lookup configuration (disable, source interface)
  - Multicast domain settings
  - Flow control and delete mode options

  Follows established terraform patterns with proper defaults support and error handling.

  ## Cisco IOS-XR Version
  24.4.2

  ## Checklist
  - [x] Latest commit is rebased from main/master with merge conflicts resolved
  - [x] All pre-commit hooks passed
