### PR TITLE
Remove delete_mode attribute from iosxr_domain resource

### DIFF
--- a/iosxr_domain.tf
+++ b/iosxr_domain.tf
@@ -11,5 +11,4 @@ resource "iosxr_domain" "domain" {
   ipv6_hosts              = try(local.device_config[each.value.name].domain.ipv6_hosts, local.defaults.iosxr.configuration.domain.ipv6_hosts, null)
   multicast               = try(local.device_config[each.value.name].domain.multicast, local.defaults.iosxr.configuration.domain.multicast, null)
   default_flows_disable   = try(local.device_config[each.value.name].domain.default_flows_disable, local.defaults.iosxr.configuration.domain.default_flows_disable, null)
-  delete_mode             = try(local.device_config[each.value.name].domain.delete_mode, local.defaults.iosxr.configuration.domain.delete_mode, null)
 }


### PR DESCRIPTION
Remove delete_mode attribute from iosxr_domain resource

## Related Issue(s)
https://wwwin-github.cisco.com/netascode/nac-iosxr/issues/9

## Proposed Changes
Removed delete_mode attribute from iosxr_domain resource

## Cisco IOS-XR Version
24.4.2

Test, validate and ensure pre-commit is run before submitting PR
- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
