### PR TITLE
fix(iosxr_snmp_server_view): correct condition for SNMP views

### DIFF
--- a/iosxr_snmp_server_view.tf
+++ b/iosxr_snmp_server_view.tf
@@ -13,7 +13,8 @@ locals {
           }
         ]
       }
-    ] if try(local.device_config[device.name].snmp_server_views, local.defaults.iosxr.configuration.snmp_server_views, null) != null
+    ]
+    if try(local.device_config[device.name].snmp_server_views, null) != null || try(local.defaults.iosxr.configuration.snmp_server_views, null) != null
   ])
 }
 


### PR DESCRIPTION
- Adjusted the condition to check for SNMP server views.
- Ensured compatibility with default configurations.

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the WIP label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

## Proposed Changes
<!--- Please provide a description of proposed changes -->

## Cisco IOS-XR Version
Version 24.4.2

## Checklist

Test, validate and ensure pre-commit is run before submitting PR
- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
