### PR TITLE
refactor(iosxr_domain): Use null values instead of empty lists

### DIFF
--- a/iosxr_domain.tf
+++ b/iosxr_domain.tf
@@ -3,12 +3,12 @@ resource "iosxr_domain" "domain" {
   device   = each.value.name
 
   name                    = try(local.device_config[each.value.name].domain.name, local.defaults.iosxr.configuration.domain.name, null)
-  domains                 = try(length(local.device_config[each.value.name].domain.domains) == 0, true) ? null : try(local.device_config[each.value.name].domain.domains, null)
   lookup_disable          = try(local.device_config[each.value.name].domain.lookup_disable, local.defaults.iosxr.configuration.domain.lookup_disable, null)
   lookup_source_interface = try(local.device_config[each.value.name].domain.lookup_source_interface, local.defaults.iosxr.configuration.domain.lookup_source_interface, null)
+  multicast               = try(local.device_config[each.value.name].domain.multicast, local.defaults.iosxr.configuration.domain.multicast, null)
+  default_flows_disable   = try(local.device_config[each.value.name].domain.default_flows_disable, local.defaults.iosxr.configuration.domain.default_flows_disable, null)
+  domains                 = try(length(local.device_config[each.value.name].domain.domains) == 0, true) ? null : try(local.device_config[each.value.name].domain.domains, null)
   name_servers            = try(length(local.device_config[each.value.name].domain.name_servers) == 0, true) ? null : try(local.device_config[each.value.name].domain.name_servers, null)
   ipv4_hosts              = try(length(local.device_config[each.value.name].domain.ipv4_hosts) == 0, true) ? null : try(local.device_config[each.value.name].domain.ipv4_hosts, null)
   ipv6_hosts              = try(length(local.device_config[each.value.name].domain.ipv6_hosts) == 0, true) ? null : try(local.device_config[each.value.name].domain.ipv6_hosts, null)
-  multicast               = try(local.device_config[each.value.name].domain.multicast, local.defaults.iosxr.configuration.domain.multicast, null)
-  default_flows_disable   = try(local.device_config[each.value.name].domain.default_flows_disable, local.defaults.iosxr.configuration.domain.default_flows_disable, null)
 }


### PR DESCRIPTION
- Updated for_each condition to include default domain check
- Removed unnecessary default values for lists in domains and name_servers

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

## Proposed Changes
<!--- Please provide a description of proposed changes -->

## Cisco IOS-XR Version
Version 24.4.2

## Checklist

Test, validate and ensure pre-commit is run before submitting PR
- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
