### PR TITLE
[ENHANCEMENT] Add support for iosxr_aaa_authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ module "iosxr" {
 
 | Name | Type |
 |------|------|
+| [iosxr_aaa_authentication.aaa_authentication](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.0/docs/resources/aaa_authentication) | resource |
 | [iosxr_as_path_set.as_path_set](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.0/docs/resources/as_path_set) | resource |
 | [iosxr_banner.banner](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.0/docs/resources/banner) | resource |
 | [iosxr_bfd.bfd](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.0/docs/resources/bfd) | resource |

--- a/iosxr_aaa_authentication.tf
+++ b/iosxr_aaa_authentication.tf
@@ -1,0 +1,34 @@
+resource "iosxr_aaa_authentication" "aaa_authentication" {
+  for_each = {
+    for device in local.devices : device.name => device
+    if try(local.device_config[device.name].aaa_authentication, null) != null ||
+    try(local.defaults.iosxr.configuration.aaa_authentication, null) != null
+  }
+  device = each.value.name
+
+  login = try(length(local.device_config[each.value.name].aaa_authentication.login) == 0, true) ? null : [
+    for login in try(local.device_config[each.value.name].aaa_authentication.login, []) : {
+      list      = login.list
+      a1_local  = try(login.a1_local, null)
+      a1_line   = try(login.a1_line, null)
+      a1_tacacs = try(login.a1_tacacs, null)
+      a1_radius = try(login.a1_radius, null)
+      a1_group  = try(login.a1_group, null)
+      a2_local  = try(login.a2_local, null)
+      a2_line   = try(login.a2_line, null)
+      a2_tacacs = try(login.a2_tacacs, null)
+      a2_radius = try(login.a2_radius, null)
+      a2_group  = try(login.a2_group, null)
+      a3_local  = try(login.a3_local, null)
+      a3_line   = try(login.a3_line, null)
+      a3_tacacs = try(login.a3_tacacs, null)
+      a3_radius = try(login.a3_radius, null)
+      a3_group  = try(login.a3_group, null)
+      a4_local  = try(login.a4_local, null)
+      a4_line   = try(login.a4_line, null)
+      a4_tacacs = try(login.a4_tacacs, null)
+      a4_radius = try(login.a4_radius, null)
+      a4_group  = try(login.a4_group, null)
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the WIP label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Proposed Changes
<!--- Please provide a description of proposed changes -->
- Added `iosxr_aaa_authentication` resource (`iosxr_aaa_authentication.tf`) to support AAA authentication login list configuration on IOS XR devices
- The resource supports up to 4 ordered authentication methods per login list (`a1_*` through `a4_*`), each accepting `tacacs`, `radius`, `local`, `line`, or a named server `group`
- Updated `examples/system/system.nac.yaml` with a representative `aaa_authentication` login list example covering all method types; `*_line` attributes are documented as commented-out entries with a note that they require line password configuration on the device

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
https://wwwin-github.cisco.com/netascode/nac-iosxr/issues/444

## Cisco IOS-XR Version
<!--- Please provide Cisco IOS-XR version developed against -->
<!--- Common versions: 24.4.2, 25.4.1 -->
24.4.2

## Checklist

<!--- Test, validate and ensure pre-commit is run before submitting PR -->
- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
