### PR TITLE
[ENHANCEMENT] Add support for iosxr_icmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ requirements.txt
 pyproject.toml
 uv.lock
 .yamllint
+.idea/
+*.iml

--- a/iosxr_icmp.tf
+++ b/iosxr_icmp.tf
@@ -1,0 +1,12 @@
+resource "iosxr_icmp" "icmp" {
+  for_each = { for device in local.devices : device.name => device if try(local.device_config[device.name].icmp, null) != null || try(local.defaults.iosxr.devices.configuration.icmp, null) != null }
+  device                                 = each.value.name
+  ipv4_rate_limit_unreachable_df_disable = try(local.device_config[each.value.name].icmp.ipv4_rate_limit_unreachable_df_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4_rate_limit_unreachable_df_disable, null)
+  ipv4_rate_limit_unreachable_df_rate    = try(local.device_config[each.value.name].icmp.ipv4_rate_limit_unreachable_df_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4_rate_limit_unreachable_df_rate, null)
+  ipv4_rate_limit_unreachable_disable    = try(local.device_config[each.value.name].icmp.ipv4_rate_limit_unreachable_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4_rate_limit_unreachable_disable, null)
+  ipv4_rate_limit_unreachable_rate       = try(local.device_config[each.value.name].icmp.ipv4_rate_limit_unreachable_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4_rate_limit_unreachable_rate, null)
+  ipv4_source_rfc                        = try(local.device_config[each.value.name].icmp.ipv4_source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv4_source_rfc, null)
+  ipv4_source_vrf                        = try(local.device_config[each.value.name].icmp.ipv4_source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv4_source_vrf, null)
+  ipv6_source_rfc                        = try(local.device_config[each.value.name].icmp.ipv6_source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv6_source_rfc, null)
+  ipv6_source_vrf                        = try(local.device_config[each.value.name].icmp.ipv6_source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv6_source_vrf, null)
+}


### PR DESCRIPTION
## Summary

Automated Terraform module for `iosxr_icmp` generated by the NAC full-lifecycle pipeline.

**Ticket:** https://wwwin-github.cisco.com/netascode/nac-iosxr/issues/666

> ⚠️ Auto-generated — requires human review before merging.

---

## Files Changed

- `iosxr_icmp.tf`

---

## Local Testing

```
terraform plan
terraform apply
terraform destroy
```

- [ ] `terraform plan` shows expected changes only
- [ ] `terraform apply` succeeds on a test device
- [ ] `terraform destroy` cleans up properly

---

## External Repo Link

- nac-iosxr PR: _(link nac-iosxr PR here)_
- Provider docs: https://registry.terraform.io/providers/CiscoDevNet/iosxr/latest/docs/resources/icmp

