### PR TITLE
fix(iosxr_prefix_list): update mask handling to use length

### DIFF
--- a/iosxr_prefix_list.tf
+++ b/iosxr_prefix_list.tf
@@ -10,7 +10,7 @@ locals {
           remark                 = try(entry.remark, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.remark, null)
           permission             = try(entry.action, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.action, null)
           prefix                 = try(entry.prefix, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.prefix, null)
-          mask                   = try(provider::utils::normalize_mask(entry.mask, "dotted-decimal"), entry.mask, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.mask, null)
+          mask                   = try(provider::utils::normalize_mask(entry.length, "dotted-decimal"), entry.length, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.length, null)
           match_prefix_length_eq = try(entry.exact_length, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.exact_length, null)
           match_prefix_length_ge = try(entry.min_length, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.min_length, null)
           match_prefix_length_le = try(entry.max_length, local.defaults.iosxr.devices.configuration.prefix_lists.ipv4.entries.max_length, null)


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the WIP label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Proposed Changes
- update mask handling to use length

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

## Cisco IOS-XR Version
24.4.2

## Checklist

<!--- Test, validate and ensure pre-commit is run before submitting PR -->
- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
