### PR TITLE
feat(icmp): add icmp NAC support

### DIFF
--- a/iosxr_icmp.tf
+++ b/iosxr_icmp.tf
@@ -2,12 +2,12 @@ resource "iosxr_icmp" "icmp" {
   for_each = { for device in local.devices : device.name => device if try(local.device_config[device.name].icmp, null) != null || try(local.defaults.iosxr.devices.configuration.icmp, null) != null }
   device   = each.value.name
 
-  ipv4_source_vrf                     = try(local.device_config[each.value.name].icmp.ipv4.source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv4.source_vrf, null)
-  ipv4_source_rfc                     = try(local.device_config[each.value.name].icmp.ipv4.source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv4.source_rfc, null)
-  ipv4_rate_limit_unreachable_rate    = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_rate, null)
-  ipv4_rate_limit_unreachable_disable = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_disable, null)
+  ipv4_source_vrf                        = try(local.device_config[each.value.name].icmp.ipv4.source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv4.source_vrf, null)
+  ipv4_source_rfc                        = try(local.device_config[each.value.name].icmp.ipv4.source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv4.source_rfc, null)
+  ipv4_rate_limit_unreachable_rate       = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_rate, null)
+  ipv4_rate_limit_unreachable_disable    = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_disable, null)
   ipv4_rate_limit_unreachable_df_rate    = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_df_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_df_rate, null)
   ipv4_rate_limit_unreachable_df_disable = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_df_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_df_disable, null)
-  ipv6_source_vrf                     = try(local.device_config[each.value.name].icmp.ipv6.source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv6.source_vrf, null)
-  ipv6_source_rfc                     = try(local.device_config[each.value.name].icmp.ipv6.source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv6.source_rfc, null)
+  ipv6_source_vrf                        = try(local.device_config[each.value.name].icmp.ipv6.source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv6.source_vrf, null)
+  ipv6_source_rfc                        = try(local.device_config[each.value.name].icmp.ipv6.source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv6.source_rfc, null)
 }

--- a/iosxr_icmp.tf
+++ b/iosxr_icmp.tf
@@ -1,0 +1,13 @@
+resource "iosxr_icmp" "icmp" {
+  for_each = { for device in local.devices : device.name => device if try(local.device_config[device.name].icmp, null) != null || try(local.defaults.iosxr.devices.configuration.icmp, null) != null }
+  device   = each.value.name
+
+  ipv4_source_vrf                     = try(local.device_config[each.value.name].icmp.ipv4.source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv4.source_vrf, null)
+  ipv4_source_rfc                     = try(local.device_config[each.value.name].icmp.ipv4.source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv4.source_rfc, null)
+  ipv4_rate_limit_unreachable_rate    = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_rate, null)
+  ipv4_rate_limit_unreachable_disable = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_disable, null)
+  ipv4_rate_limit_unreachable_df_rate    = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_df_rate, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_df_rate, null)
+  ipv4_rate_limit_unreachable_df_disable = try(local.device_config[each.value.name].icmp.ipv4.rate_limit_unreachable_df_disable, local.defaults.iosxr.devices.configuration.icmp.ipv4.rate_limit_unreachable_df_disable, null)
+  ipv6_source_vrf                     = try(local.device_config[each.value.name].icmp.ipv6.source_vrf, local.defaults.iosxr.devices.configuration.icmp.ipv6.source_vrf, null)
+  ipv6_source_rfc                     = try(local.device_config[each.value.name].icmp.ipv6.source_rfc, local.defaults.iosxr.devices.configuration.icmp.ipv6.source_rfc, null)
+}

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_ftp.ftp,
     iosxr_gnmi.gnmi,
     iosxr_hostname.hostname,
+    iosxr_icmp.icmp,
     iosxr_interface_bundle_ether.bundle_ether,
     iosxr_interface_bundle_ether_subinterface.bundle_ether_subinterface,
     iosxr_interface_bvi.bvi,


### PR DESCRIPTION
## Proposed Changes

Added Terraform module and main.tf wiring for the `icmp` IOS-XR NAC feature.

**Files changed:**
- `iosxr_icmp.tf` — new Terraform module for ICMP configuration (IPv4/IPv6 source and rate-limit settings)
- `main.tf` — added `iosxr_icmp.icmp` to `iosxr_cli.cli_0` depends_on list

## Related Issue(s)

<!-- Link if applicable -->

## Cisco IOS-XR Version

<!-- Fill in the IOS-XR version tested against -->

## Checklist

- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
