### PR TITLE
Add support for the contexts attribute on the iosxr_snmp_server resource

### DIFF
--- a/iosxr_snmp_server.tf
+++ b/iosxr_snmp_server.tf
@@ -260,6 +260,10 @@ resource "iosxr_snmp_server" "snmp_server" {
     ]
     }
   ]
+  contexts = try(length(local.device_config[each.value.name].snmp_server.contexts) == 0, true) ? null : [for context in local.device_config[each.value.name].snmp_server.contexts : {
+    name = try(context.name, local.defaults.iosxr.devices.configuration.snmp_server.contexts.name, null)
+    }
+  ]
 }
 
 ##### SNMP Server VRFs #####


### PR DESCRIPTION
## Proposed Changes

Add support for the contexts attribute on the iosxr_snmp_server resource, allowing SNMP contexts to be defined at the global SNMP server.

## Related Issue(s)

Depends on upstream provider: CiscoDevNet/terraform-provider-iosxr PR #333

## Cisco IOS-XR Version
Tested against 25.4.2

## Checklist

- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
