### PR TITLE
refactor(model): drop legacy device-level cli_templates fallback

### DIFF
--- a/modules/model/main.tf
+++ b/modules/model/main.tf
@@ -195,8 +195,7 @@ locals {
     device.name => concat(
       [for name, template in local.global_cli_templates[device.name] : { "name" = name, "content" = template.content, "order" = template.order }],
       [for name, template in local.group_cli_templates[device.name] : { "name" = name, "content" = template.content, "order" = template.order }],
-      [for name, template in local.device_cli_templates[device.name] : { "name" = name, "content" = template.content, "order" = template.order }],
-      try(device.cli_templates, [])
+      [for name, template in local.device_cli_templates[device.name] : { "name" = name, "content" = template.content, "order" = template.order }]
     )
   }
 


### PR DESCRIPTION
## Proposed Changes
Removes the legacy `try(device.cli_templates, [])` fallback in `modules/model/main.tf`.
CLI templates now resolve solely from the unified `templates` schema (`type: cli`).

## Related Issue(s)

## Cisco IOS-XR Version
24.4.2

## Checklist
- [x] Latest commit is rebased from main with merge conflicts resolved
- [x] All pre-commit hooks passed

<!-- BREAKING CHANGE: device-level cli_templates input is no longer honored; use the templates (type: cli) structure. -->
