### PR TITLE
fix(cli): preserve newlines in multi-line CLI templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0
 
 - BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope
+- Fix: preserve newlines in multi-line CLI templates so IOS-XR submode configuration is applied correctly instead of being collapsed onto a single line (requires provider >= 0.7.2)
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0
+## Unreleased
 
 - BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope
 - Fix: preserve newlines in multi-line CLI templates so IOS-XR submode configuration is applied correctly instead of being collapsed onto a single line (requires provider >= 0.7.2)

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 0
     ]
   ])
@@ -43,7 +43,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 1
     ]
   ])
@@ -52,7 +52,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 2
     ]
   ])
@@ -61,7 +61,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 3
     ]
   ])
@@ -70,7 +70,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 4
     ]
   ])
@@ -79,7 +79,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 5
     ]
   ])
@@ -88,7 +88,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 6
     ]
   ])
@@ -97,7 +97,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 7
     ]
   ])
@@ -106,7 +106,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 8
     ]
   ])
@@ -115,7 +115,7 @@ locals {
       for template in try(device.cli_templates, []) : {
         key     = format("%s/%s", device.name, template.name)
         device  = device.name
-        content = join(" ", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
+        content = join("\n", [for line in split("\n", template.content) : trimspace(line) if trimspace(line) != ""])
       } if try(template.order, local.defaults.iosxr.templates.order) == 9
     ]
   ])


### PR DESCRIPTION
## Proposed Changes
CLI template content was joined with a space, collapsing multi-line templates into one line. IOS-XR only parses submode configuration when newlines are preserved, so multi-line CLI templates were applied as invalid single-line commands.

Join template lines with `\n` instead so multi-line CLI submode configuration reaches the device correctly.

## Related Issue(s)
Fixes netascode/terraform-iosxr-nac-iosxr#192

## Cisco IOS-XR Version
24.4.2 (XRv9K)

## Dependency
Requires the companion provider fix that JSON-encodes (gNMI) and XML-escapes (NETCONF) the `iosxr_cli` payload: **CiscoDevNet/terraform-provider-iosxr#351** (targeted for provider 0.7.2). With the released 0.7.1 provider, sending real newlines over gNMI fails (invalid JSON), so bump the provider pin to `>= 0.7.2` before relying on this in a pinned release.

## Checklist
- [x] Latest commit is rebased from main with merge conflicts resolved
- [ ] All pre-commit hooks passed

Co-authored-by: Robert Crowe <rocrowe@cisco.com>