### PR TITLE
refactor(yang): rename iosxr_gnmi resource to iosxr_yang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0
 
 - BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope
+- BREAKING CHANGE: Rename the `iosxr.devices.configuration.gnmi` data-model key to `yang` and adopt the provider `iosxr_yang` resource (previously `iosxr_gnmi`); update NAC data accordingly (requires provider >= 0.7.2)
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.2.0
+## Unreleased
 
 - BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope
-- BREAKING CHANGE: Rename the `iosxr.devices.configuration.gnmi` data-model key to `yang` and adopt the provider `iosxr_yang` resource (previously `iosxr_gnmi`); update NAC data accordingly (requires provider >= 0.7.2)
+- BREAKING CHANGE: Rename the `iosxr_gnmi` resource to `iosxr_yang`. The new resource can be used with GNMI and Netconf transport protocols.
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ module "iosxr" {
 | [iosxr_flow_sampler_map.flow_sampler_map](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/flow_sampler_map) | resource |
 | [iosxr_fpd.fpd](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/fpd) | resource |
 | [iosxr_ftp.ftp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/ftp) | resource |
-| [iosxr_gnmi.gnmi](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/gnmi) | resource |
 | [iosxr_hostname.hostname](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/hostname) | resource |
 | [iosxr_interface_bundle_ether.bundle_ether](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/interface_bundle_ether) | resource |
 | [iosxr_interface_bundle_ether_subinterface.bundle_ether_subinterface](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/interface_bundle_ether_subinterface) | resource |
@@ -222,6 +221,7 @@ module "iosxr" {
 | [iosxr_vrf.vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vrf) | resource |
 | [iosxr_vty_pool.vty_pool](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vty_pool) | resource |
 | [iosxr_xml_agent.xml_agent](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/xml_agent) | resource |
+| [iosxr_yang.yang](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/yang) | resource |
 | [terraform_data.bundle_ether_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.bundle_ether_subinterface_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.control_plane_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/iosxr_yang.tf
+++ b/iosxr_yang.tf
@@ -1,12 +1,12 @@
 locals {
-  gnmi = flatten([
+  yang = flatten([
     for device in local.devices : [
-      for gnmi_name, gnmi in try(local.device_config[device.name].gnmi, {}) : {
-        key         = format("%s/%s", device.name, gnmi_name)
+      for yang_name, yang in try(local.device_config[device.name].yang, {}) : {
+        key         = format("%s/%s", device.name, yang_name)
         device_name = device.name
-        path        = try(gnmi.path, null)
-        attributes  = try(gnmi.attributes, null)
-        # lists       = try(length(gnmi.lists) == 0, true) ? null : [for list in gnmi.lists : {
+        path        = try(yang.path, null)
+        attributes  = try(yang.attributes, null)
+        # lists       = try(length(yang.lists) == 0, true) ? null : [for list in yang.lists : {
         #   name   = try(list.name, null)
         #   key    = try(list.key, null)
         #   items  = try(list.items, null)
@@ -18,8 +18,8 @@ locals {
   ])
 }
 
-resource "iosxr_gnmi" "gnmi" {
-  for_each   = { for gnmi in local.gnmi : gnmi.key => gnmi }
+resource "iosxr_yang" "yang" {
+  for_each   = { for yang in local.yang : yang.key => yang }
   device     = each.value.device_name
   path       = each.value.path
   attributes = each.value.attributes

--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_flow_sampler_map.flow_sampler_map,
     iosxr_fpd.fpd,
     iosxr_ftp.ftp,
-    iosxr_gnmi.gnmi,
+    iosxr_yang.yang,
     iosxr_hostname.hostname,
     iosxr_interface_bundle_ether.bundle_ether,
     iosxr_interface_bundle_ether_subinterface.bundle_ether_subinterface,


### PR DESCRIPTION
## Proposed Changes
Adopt the provider 0.7.2 rename of the `iosxr_gnmi` resource/data source to `iosxr_yang`, and rename the corresponding NAC data-model attribute read from `gnmi` to `yang` for consistency.

- Replace `iosxr_gnmi.tf` with `iosxr_yang.tf` (resource `iosxr_yang.yang`)
- Read device `configuration.yang` instead of `configuration.gnmi`
- Update `iosxr_cli` `depends_on` reference
- Update README resource table

## Related Issue(s)
Companion to the `nac-iosxr` data-model rename PR. Depends on provider `iosxr` >= 0.7.2 (where `iosxr_yang` exists).

## Cisco IOS-XR Version
24.4.2 (XRv9K)

## Checklist
- [x] Latest commit is rebased from main with merge conflicts resolved
- [x] All pre-commit hooks passed

<!-- BREAKING CHANGE: iosxr.devices.configuration.gnmi renamed to yang; requires provider >= 0.7.2. Opened as draft. -->

Co-authored-by: Robert Crowe <rocrowe@cisco.com>