### PR TITLE
docs(changelog): backfill 0.2.0 entry and switch to newest-first ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,7 @@
   - Standardize OSPF, IS-IS, and static route resources with consistent naming and enum values
   - Normalize MAC address formats automatically across interfaces, LACP, and HSRP
   - Normalize route distinguisher and route target parsing across BGP and VRF resources
+
+## 0.2.0
+
+- BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.1.0
+## 0.2.0
 
-- Initial release
+- BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope
 
 ## 0.1.1
 
@@ -24,6 +24,6 @@
   - Normalize MAC address formats automatically across interfaces, LACP, and HSRP
   - Normalize route distinguisher and route target parsing across BGP and VRF resources
 
-## 0.2.0
+## 0.1.0
 
-- BREAKING CHANGE: Remove the deprecated device-level `cli_templates` attribute. Define CLI templates via the unified `templates` structure with `type: cli`, applied by name at global/device-group/device scope
+- Initial release


### PR DESCRIPTION
## Summary

- [#199](https://github.com/netascode/terraform-iosxr-nac-iosxr/pull/199) removed the deprecated device-level `cli_templates` attribute but merged without a `CHANGELOG.md` entry. This adds the missing `0.2.0` release note for that breaking change.
- Reorders `CHANGELOG.md` to newest-first (`0.2.0`, `0.1.1`, `0.1.0`), matching the [Keep a Changelog](https://keepachangelog.com/) convention and the sibling [provider `CHANGELOG.md`](https://github.com/CiscoDevNet/terraform-provider-iosxr/blob/main/CHANGELOG.md).

## Notes

- Docs-only change; no code or behavior impact.
- The open PRs [#200](https://github.com/netascode/terraform-iosxr-nac-iosxr/pull/200) (multi-line CLI fix) and [#201](https://github.com/netascode/terraform-iosxr-nac-iosxr/pull/201) (`iosxr_gnmi` -> `iosxr_yang` rename) also place their `0.2.0` bullet at the top using the same newest-first order, so `0.1.x` stays identical across branches and only the `0.2.0` section needs a trivial merge to consolidate the three bullets.

Co-authored-by: Robert Crowe <rocrowe@cisco.com>