### PR TITLE
feat(snmp_server): map contexts and context mappings

### DIFF
--- a/iosxr_snmp_server.tf
+++ b/iosxr_snmp_server.tf
@@ -260,6 +260,18 @@ resource "iosxr_snmp_server" "snmp_server" {
     ]
     }
   ]
+  contexts = try(length(local.device_config[each.value.name].snmp_server.contexts) == 0, true) ? null : [for context in local.device_config[each.value.name].snmp_server.contexts : {
+    name = try(context.name, local.defaults.iosxr.devices.configuration.snmp_server.contexts.name, null)
+    }
+  ]
+  context_mappings = try(length(local.device_config[each.value.name].snmp_server.context_mappings) == 0, true) ? null : [for mapping in local.device_config[each.value.name].snmp_server.context_mappings : {
+    name     = try(mapping.name, local.defaults.iosxr.devices.configuration.snmp_server.context_mappings.name, null)
+    feature  = try(mapping.feature, local.defaults.iosxr.devices.configuration.snmp_server.context_mappings.feature, null)
+    instance = try(mapping.instance, local.defaults.iosxr.devices.configuration.snmp_server.context_mappings.instance, null)
+    vrf      = try(mapping.vrf, local.defaults.iosxr.devices.configuration.snmp_server.context_mappings.vrf, null)
+    topology = try(mapping.topology, local.defaults.iosxr.devices.configuration.snmp_server.context_mappings.topology, null)
+    }
+  ]
 }
 
 ##### SNMP Server VRFs #####


### PR DESCRIPTION
## Summary

Maps the SNMP server **contexts** and **context mappings** from the NAC data model to the `iosxr_snmp_server` provider resource.

- `iosxr_snmp_server.tf`: add `contexts` and `context_mappings` blocks following the existing `flatten()` / `try()` list patterns
  - `contexts[].name`
  - `context_mappings[].{name, feature, instance, vrf, topology}`

## Dependencies

- Requires the `contexts` / `context_mappings` attributes added to the provider in CiscoDevNet/terraform-provider-iosxr#353 (targeting provider **0.7.2**).
- Pairs with the data-model PR netascode/nac-iosxr#805.

Supersedes/Closes #187 (which targeted the older provider PR #333) and completes the snmp_server context/mapping addition.

## Draft status

Kept as **draft** until provider **0.7.2** is published; `versions.tf` currently pins `= 0.7.1`.. Once 0.7.2 ships, bump the version constraint and mark ready.

## Test plan

- [x] `terraform fmt` / `tflint` / `terraform validate` (against locally compiled #353 provider via dev_overrides)
- [x] Full integration `pytest` against lab device (with provider 0.7.2)
