### PR TITLE
fix(banner): strip trailing newline from banner line to prevent NETCONF drift

### DIFF
--- a/iosxr_banner.tf
+++ b/iosxr_banner.tf
@@ -15,5 +15,5 @@ resource "iosxr_banner" "banner" {
   for_each    = { for banner in local.banners : banner.key => banner }
   device      = each.value.device_name
   banner_type = each.value.banner_type
-  line        = each.value.line
+  line        = chomp(each.value.line)
 }


### PR DESCRIPTION
## Summary

- Apply `chomp()` to `iosxr_banner.line` in the TF module to strip the trailing newline that YAML block scalars (`|`) always append
- This prevents config drift when paired with the IOS-XR provider fix in CiscoDevNet/terraform-provider-iosxr#359, where the NETCONF read path was unconditionally appending `\n` to all banner `line` values read from the device
- The device stores banner content without a trailing newline; `chomp()` ensures the value written matches what will be read back, making plan/apply/plan idempotent

## Test plan

- [x] Verify `terraform plan` shows no drift after initial `apply`
- [x] Verify all six banner types: `login`, `motd`, `exec`, `incoming`, `prompt-timeout`, `slip-ppp`
- [x] Verify both NETCONF and gNMI transports produce no drift