### PR TITLE
feat(tacacs_source_interface): add tacacs_source_interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ module "iosxr" {
 | [iosxr_snmp_server_vrf.snmp_server_vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/snmp_server_vrf) | resource |
 | [iosxr_ssh.ssh](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/ssh) | resource |
 | [iosxr_tacacs_server.tacacs_server](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/tacacs_server) | resource |
+| [iosxr_tacacs_source_interface.tacacs_source_interface](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/tacacs_source_interface) | resource |
 | [iosxr_tag_set.tag_set](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/tag_set) | resource |
 | [iosxr_tcp.tcp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/tcp) | resource |
 | [iosxr_telemetry_model_driven.telemetry_model_driven](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/telemetry_model_driven) | resource |

--- a/iosxr_tacacs_server.tf
+++ b/iosxr_tacacs_server.tf
@@ -1,3 +1,5 @@
+##### TACACS Server #####
+
 resource "iosxr_tacacs_server" "tacacs_server" {
   for_each      = { for device in local.devices : device.name => device if try(local.device_config[device.name].tacacs_server, null) != null || try(local.defaults.iosxr.devices.configuration.tacacs_server, null) != null }
   device        = each.value.name
@@ -22,6 +24,8 @@ resource "iosxr_tacacs_server" "tacacs_server" {
     }
   ]
 }
+
+##### TACACS Source Interface #####
 
 locals {
   tacacs_source_interface = flatten([

--- a/iosxr_tacacs_server.tf
+++ b/iosxr_tacacs_server.tf
@@ -22,3 +22,33 @@ resource "iosxr_tacacs_server" "tacacs_server" {
     }
   ]
 }
+
+locals {
+  tacacs_source_interface = flatten([
+    for device in local.devices : [
+      {
+        key         = device.name
+        device_name = device.name
+        source_interface = try(
+          [for si in local.device_config[device.name].tacacs_source_interface : si.interface if try(si.vrf, null) == null][0],
+          local.defaults.iosxr.devices.configuration.tacacs_source_interface.interface,
+          null
+        )
+        source_interfaces = try(length([for si in try(local.device_config[device.name].tacacs_source_interface, []) : si if try(si.vrf, null) != null]) == 0, true) ? null : [
+          for si in local.device_config[device.name].tacacs_source_interface : {
+            vrf       = try(si.vrf, local.defaults.iosxr.devices.configuration.tacacs_source_interface.vrf, null)
+            interface = try(si.interface, local.defaults.iosxr.devices.configuration.tacacs_source_interface.interface, null)
+          } if try(si.vrf, null) != null
+        ]
+      }
+    ] if try(local.device_config[device.name].tacacs_source_interface, null) != null ||
+    try(local.defaults.iosxr.devices.configuration.tacacs_source_interface, null) != null
+  ])
+}
+
+resource "iosxr_tacacs_source_interface" "tacacs_source_interface" {
+  for_each          = { for v in local.tacacs_source_interface : v.key => v }
+  device            = each.value.device_name
+  source_interface  = each.value.source_interface
+  source_interfaces = each.value.source_interfaces
+}

--- a/main.tf
+++ b/main.tf
@@ -262,6 +262,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_snmp_server_mib.snmp_server_mib,
     iosxr_ssh.ssh,
     iosxr_tacacs_server.tacacs_server,
+    iosxr_tacacs_source_interface.tacacs_source_interface,
     iosxr_tag_set.tag_set,
     iosxr_tcp.tcp,
     iosxr_tftp_client.tftp_client,


### PR DESCRIPTION
## Proposed Changes

Added Terraform module and main.tf wiring for the `tacacs_source_interface` IOS-XR feature.

The module supports a global source interface (no VRF) and per-VRF source interfaces within a single resource per device. Entries without a `vrf` key map to the provider's top-level `source_interface` attribute; entries with a `vrf` key populate the `source_interfaces` list.

**Files changed:**
- `iosxr_tacacs_server.tf` — added `tacacs_source_interface` locals and resource
- `main.tf` — added depends_on entry for `iosxr_tacacs_source_interface`
- `README.md` — auto-updated by terraform-docs

## Related Issue(s)

<!-- Link if user provides an issue number; otherwise leave empty -->

## Cisco IOS-XR Version

**Device(s) tested on:**

- [x] XRv9K    - IOS-XR version: 24.4.2
- [x] NCS5xxx  - IOS-XR version: 24.4.2
- [x] C8000    - IOS-XR version: 24.4.2

## Checklist

- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed
