### PR TITLE
feat(provider-0.7.2): add support for provider 0.7.2 attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ module "iosxr" {
 | [iosxr_linux_networking.linux_networking](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/linux_networking) | resource |
 | [iosxr_lldp.lldp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/lldp) | resource |
 | [iosxr_logging.logging](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging) | resource |
-| [iosxr_logging_link_status.logging_link_status](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging_link_status) | resource |
+| [iosxr_logging_events_link_status.logging_events_link_status](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging_events_link_status) | resource |
 | [iosxr_logging_vrf.logging_vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging_vrf) | resource |
 | [iosxr_mac_set.mac_set](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/mac_set) | resource |
 | [iosxr_monitor_session.monitor_session](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/monitor_session) | resource |

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ module "iosxr" {
 | [iosxr_vrf.vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vrf) | resource |
 | [iosxr_vty_pool.vty_pool](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vty_pool) | resource |
 | [iosxr_xml_agent.xml_agent](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/xml_agent) | resource |
-| [iosxr_yang.yang](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/yang) | resource |
 | [terraform_data.bundle_ether_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.bundle_ether_subinterface_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.control_plane_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ module "iosxr" {
 | [iosxr_vrf.vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vrf) | resource |
 | [iosxr_vty_pool.vty_pool](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vty_pool) | resource |
 | [iosxr_xml_agent.xml_agent](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/xml_agent) | resource |
+| [iosxr_yang.yang](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/yang) | resource |
 | [terraform_data.bundle_ether_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.bundle_ether_subinterface_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.control_plane_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ module "iosxr" {
 | [iosxr_ftp.ftp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/ftp) | resource |
 | [iosxr_gnmi.gnmi](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/gnmi) | resource |
 | [iosxr_hostname.hostname](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/hostname) | resource |
+| [iosxr_http_client.http_client](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/http_client) | resource |
 | [iosxr_interface_bundle_ether.bundle_ether](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/interface_bundle_ether) | resource |
 | [iosxr_interface_bundle_ether_subinterface.bundle_ether_subinterface](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/interface_bundle_ether_subinterface) | resource |
 | [iosxr_interface_bvi.bvi](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/interface_bvi) | resource |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ module "iosxr" {
 | [iosxr_cli.cli_7](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/cli) | resource |
 | [iosxr_cli.cli_8](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/cli) | resource |
 | [iosxr_cli.cli_9](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/cli) | resource |
+| [iosxr_clock.clock](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/clock) | resource |
 | [iosxr_community_set.community_set](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/community_set) | resource |
 | [iosxr_control_plane.control_plane](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/control_plane) | resource |
 | [iosxr_domain.domain](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/domain) | resource |
@@ -228,6 +229,7 @@ module "iosxr" {
 | [iosxr_vrf.vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vrf) | resource |
 | [iosxr_vty_pool.vty_pool](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/vty_pool) | resource |
 | [iosxr_xml_agent.xml_agent](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/xml_agent) | resource |
+| [iosxr_yang.yang](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/yang) | resource |
 | [terraform_data.bundle_ether_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.bundle_ether_subinterface_flow_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.control_plane_replace](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ module "iosxr" {
 | [iosxr_linux_networking.linux_networking](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/linux_networking) | resource |
 | [iosxr_lldp.lldp](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/lldp) | resource |
 | [iosxr_logging.logging](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging) | resource |
+| [iosxr_logging_link_status.logging_link_status](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging_link_status) | resource |
 | [iosxr_logging_vrf.logging_vrf](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/logging_vrf) | resource |
 | [iosxr_mac_set.mac_set](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/mac_set) | resource |
 | [iosxr_monitor_session.monitor_session](https://registry.terraform.io/providers/CiscoDevNet/iosxr/0.7.1/docs/resources/monitor_session) | resource |

--- a/iosxr_clock.tf
+++ b/iosxr_clock.tf
@@ -1,0 +1,5 @@
+resource "iosxr_clock" "clock" {
+  for_each = { for device in local.devices : device.name => device if try(local.device_config[device.name].clock, null) != null || try(local.defaults.iosxr.devices.configuration.clock, null) != null }
+  device   = each.value.name
+  timezone = try(local.device_config[each.value.name].clock.timezone, local.defaults.iosxr.devices.configuration.clock.timezone, null)
+}

--- a/iosxr_http_client.tf
+++ b/iosxr_http_client.tf
@@ -1,0 +1,48 @@
+locals {
+  http_client = flatten([
+    for device in local.devices : [
+      {
+        key                        = device.name
+        device_name                = device.name
+        vrf                        = try(local.device_config[device.name].http_client.vrf, local.defaults.iosxr.devices.configuration.http_client.vrf, null)
+        response_timeout           = try(local.device_config[device.name].http_client.response_timeout, local.defaults.iosxr.devices.configuration.http_client.response_timeout, null)
+        connection_timeout         = try(local.device_config[device.name].http_client.connection_timeout, local.defaults.iosxr.devices.configuration.http_client.connection_timeout, null)
+        connection_retry           = try(local.device_config[device.name].http_client.connection_retry, local.defaults.iosxr.devices.configuration.http_client.connection_retry, null)
+        source_interface_ipv4      = try(local.device_config[device.name].http_client.source_interface_ipv4, local.defaults.iosxr.devices.configuration.http_client.source_interface_ipv4, null)
+        source_interface_ipv6      = try(local.device_config[device.name].http_client.source_interface_ipv6, local.defaults.iosxr.devices.configuration.http_client.source_interface_ipv6, null)
+        secure_verify_peer_disable = try(local.device_config[device.name].http_client.secure_verify_peer_disable, local.defaults.iosxr.devices.configuration.http_client.secure_verify_peer_disable, null)
+        secure_verify_host_disable = try(local.device_config[device.name].http_client.secure_verify_host_disable, local.defaults.iosxr.devices.configuration.http_client.secure_verify_host_disable, null)
+        tcp_window_scale           = try(local.device_config[device.name].http_client.tcp_window_scale, local.defaults.iosxr.devices.configuration.http_client.tcp_window_scale, null)
+        version_default            = try(local.device_config[device.name].http_client.version, local.defaults.iosxr.devices.configuration.http_client.version, null) == "default" ? true : null
+        version_10                 = try(local.device_config[device.name].http_client.version, local.defaults.iosxr.devices.configuration.http_client.version, null) == "1.0" ? true : null
+        version_11                 = try(local.device_config[device.name].http_client.version, local.defaults.iosxr.devices.configuration.http_client.version, null) == "1.1" ? true : null
+        ssl_version_tls10          = try(local.device_config[device.name].http_client.ssl_version, local.defaults.iosxr.devices.configuration.http_client.ssl_version, null) == "tls-1.0" ? true : null
+        ssl_version_tls11          = try(local.device_config[device.name].http_client.ssl_version, local.defaults.iosxr.devices.configuration.http_client.ssl_version, null) == "tls-1.1" ? true : null
+        ssl_version_tls12          = try(local.device_config[device.name].http_client.ssl_version, local.defaults.iosxr.devices.configuration.http_client.ssl_version, null) == "tls-1.2" ? true : null
+        ssl_version_tls13          = try(local.device_config[device.name].http_client.ssl_version, local.defaults.iosxr.devices.configuration.http_client.ssl_version, null) == "tls-1.3" ? true : null
+      }
+    ] if try(local.device_config[device.name].http_client, null) != null ||
+    try(local.defaults.iosxr.devices.configuration.http_client, null) != null
+  ])
+}
+
+resource "iosxr_http_client" "http_client" {
+  for_each                   = { for v in local.http_client : v.key => v }
+  device                     = each.value.device_name
+  vrf                        = each.value.vrf
+  response_timeout           = each.value.response_timeout
+  connection_timeout         = each.value.connection_timeout
+  connection_retry           = each.value.connection_retry
+  source_interface_ipv4      = each.value.source_interface_ipv4
+  source_interface_ipv6      = each.value.source_interface_ipv6
+  secure_verify_peer_disable = each.value.secure_verify_peer_disable
+  secure_verify_host_disable = each.value.secure_verify_host_disable
+  version_default            = each.value.version_default
+  version_10                 = each.value.version_10
+  version_11                 = each.value.version_11
+  ssl_version_tls10          = each.value.ssl_version_tls10
+  ssl_version_tls11          = each.value.ssl_version_tls11
+  ssl_version_tls12          = each.value.ssl_version_tls12
+  ssl_version_tls13          = each.value.ssl_version_tls13
+  tcp_window_scale           = each.value.tcp_window_scale
+}

--- a/iosxr_interface.tf
+++ b/iosxr_interface.tf
@@ -1713,6 +1713,10 @@ locals {
           ),
           null
         )
+        macsec_psk_keychain_name     = try(be.macsec_psk_keychain, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.macsec_psk_keychain, null)
+        macsec_fallback_psk_keychain = try(be.macsec_fallback_psk_keychain, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.macsec_fallback_psk_keychain, null)
+        macsec_policy                = try(be.macsec_policy, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.macsec_policy, null)
+        macsec_eap_policy            = try(be.macsec_eap_policy, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.macsec_eap_policy, null)
         monitor_sessions = try(length(be.monitor_sessions) == 0, true) ? null : [for session in be.monitor_sessions : {
           session_name      = try(session.name, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.monitor_sessions.name, null)
           ethernet          = try(session.type, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.monitor_sessions.type, "ethernet") == "ethernet" ? true : null
@@ -2001,6 +2005,10 @@ resource "iosxr_interface_bundle_ether" "bundle_ether" {
   bfd_address_family_ipv6_timers_start                      = each.value.bfd_address_family_ipv6_timers_start
   bfd_address_family_ipv6_timers_nbr_unconfig               = each.value.bfd_address_family_ipv6_timers_nbr_unconfig
   mac_address                                               = each.value.mac_address
+  macsec_psk_keychain_name                                  = each.value.macsec_psk_keychain_name
+  macsec_fallback_psk_keychain                              = each.value.macsec_fallback_psk_keychain
+  macsec_policy                                             = each.value.macsec_policy
+  macsec_eap_policy                                         = each.value.macsec_eap_policy
   monitor_sessions                                          = each.value.monitor_sessions
   mpls_mtu                                                  = each.value.mpls_mtu
   lldp                                                      = each.value.lldp
@@ -2261,6 +2269,10 @@ locals {
           arp_gratuitous_ignore                                = try(subint.arp_gratuitous_ignore, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.arp_gratuitous_ignore, null)
           arp_cache_limit                                      = try(subint.arp_cache_limit, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.arp_cache_limit, null)
           proxy_arp                                            = try(subint.proxy_arp, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.proxy_arp, null)
+          macsec_psk_keychain_name                             = try(subint.macsec_psk_keychain, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.macsec_psk_keychain, null)
+          macsec_fallback_psk_keychain                         = try(subint.macsec_fallback_psk_keychain, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.macsec_fallback_psk_keychain, null)
+          macsec_policy                                        = try(subint.macsec_policy, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.macsec_policy, null)
+          macsec_eap_policy                                    = try(subint.macsec_eap_policy, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.macsec_eap_policy, null)
           monitor_sessions = try(length(subint.monitor_sessions) == 0, true) ? null : [for session in subint.monitor_sessions : {
             session_name      = try(session.name, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.monitor_sessions.name, null)
             ethernet          = try(session.type, local.defaults.iosxr.devices.configuration.interfaces.bundle_ethernets.subinterfaces.monitor_sessions.type, "ethernet") == "ethernet" ? true : null
@@ -2522,6 +2534,10 @@ resource "iosxr_interface_bundle_ether_subinterface" "bundle_ether_subinterface"
   arp_gratuitous_ignore                                     = each.value.arp_gratuitous_ignore
   arp_cache_limit                                           = each.value.arp_cache_limit
   proxy_arp                                                 = each.value.proxy_arp
+  macsec_psk_keychain_name                                  = each.value.macsec_psk_keychain_name
+  macsec_fallback_psk_keychain                              = each.value.macsec_fallback_psk_keychain
+  macsec_policy                                             = each.value.macsec_policy
+  macsec_eap_policy                                         = each.value.macsec_eap_policy
   monitor_sessions                                          = each.value.monitor_sessions
   mpls_mtu                                                  = each.value.mpls_mtu
   lldp                                                      = each.value.lldp

--- a/iosxr_logging_events_link_status.tf
+++ b/iosxr_logging_events_link_status.tf
@@ -1,6 +1,6 @@
 resource "iosxr_logging_events_link_status" "logging_events_link_status" {
-  for_each            = { for device in local.devices : device.name => device if try(local.device_config[device.name].logging.link_status, null) != null || try(local.defaults.iosxr.devices.configuration.logging.link_status, null) != null }
+  for_each            = { for device in local.devices : device.name => device if try(local.device_config[device.name].logging.events.link_status, null) != null || try(local.defaults.iosxr.devices.configuration.logging.events.link_status, null) != null }
   device              = each.value.name
-  software_interfaces = try(local.device_config[each.value.name].logging.link_status, local.defaults.iosxr.devices.configuration.logging.link_status, null) == "software-interfaces" ? true : null
-  disable             = try(local.device_config[each.value.name].logging.link_status, local.defaults.iosxr.devices.configuration.logging.link_status, null) == "disable" ? true : null
+  software_interfaces = try(local.device_config[each.value.name].logging.events.link_status, local.defaults.iosxr.devices.configuration.logging.events.link_status, null) == "software-interfaces" ? true : null
+  disable             = try(local.device_config[each.value.name].logging.events.link_status, local.defaults.iosxr.devices.configuration.logging.events.link_status, null) == "disable" ? true : null
 }

--- a/iosxr_logging_events_link_status.tf
+++ b/iosxr_logging_events_link_status.tf
@@ -1,4 +1,4 @@
-resource "iosxr_logging_link_status" "logging_link_status" {
+resource "iosxr_logging_events_link_status" "logging_events_link_status" {
   for_each            = { for device in local.devices : device.name => device if try(local.device_config[device.name].logging.link_status, null) != null || try(local.defaults.iosxr.devices.configuration.logging.link_status, null) != null }
   device              = each.value.name
   software_interfaces = try(local.device_config[each.value.name].logging.link_status, local.defaults.iosxr.devices.configuration.logging.link_status, null) == "software-interfaces" ? true : null

--- a/iosxr_logging_link_status.tf
+++ b/iosxr_logging_link_status.tf
@@ -1,0 +1,6 @@
+resource "iosxr_logging_link_status" "logging_link_status" {
+  for_each            = { for device in local.devices : device.name => device if try(local.device_config[device.name].logging.link_status, null) != null || try(local.defaults.iosxr.devices.configuration.logging.link_status, null) != null }
+  device              = each.value.name
+  software_interfaces = try(local.device_config[each.value.name].logging.link_status, local.defaults.iosxr.devices.configuration.logging.link_status, null) == "software-interfaces" ? true : null
+  disable             = try(local.device_config[each.value.name].logging.link_status, local.defaults.iosxr.devices.configuration.logging.link_status, null) == "disable" ? true : null
+}

--- a/iosxr_mpls_ldp.tf
+++ b/iosxr_mpls_ldp.tf
@@ -47,6 +47,7 @@ resource "iosxr_mpls_ldp" "mpls_ldp" {
   neighbor_dual_stack_transport_connection_prefer_ipv4     = try(local.device_config[each.value.name].mpls_ldp.neighbor_dual_stack_transport_connection_prefer_ipv4, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_dual_stack_transport_connection_prefer_ipv4, null)
   neighbor_dual_stack_transport_connection_max_wait        = try(local.device_config[each.value.name].mpls_ldp.neighbor_dual_stack_transport_connection_max_wait, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_dual_stack_transport_connection_max_wait, null)
   neighbor_dual_stack_tlv_compliance                       = try(local.device_config[each.value.name].mpls_ldp.neighbor_dual_stack_tlv_compliance, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_dual_stack_tlv_compliance, null)
+  neighbor_password_encrypted                              = try(local.device_config[each.value.name].mpls_ldp.neighbor_password_encrypted, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_password_encrypted, null)
   neighbors = try(length(local.device_config[each.value.name].mpls_ldp.neighbors) == 0, true) ? null : [for neighbor in local.device_config[each.value.name].mpls_ldp.neighbors : {
     neighbor_address   = try(neighbor.address, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbors.address, null)
     label_space_id     = try(neighbor.label_space_id, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbors.label_space_id, null)

--- a/iosxr_mpls_ldp.tf
+++ b/iosxr_mpls_ldp.tf
@@ -47,7 +47,7 @@ resource "iosxr_mpls_ldp" "mpls_ldp" {
   neighbor_dual_stack_transport_connection_prefer_ipv4     = try(local.device_config[each.value.name].mpls_ldp.neighbor_dual_stack_transport_connection_prefer_ipv4, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_dual_stack_transport_connection_prefer_ipv4, null)
   neighbor_dual_stack_transport_connection_max_wait        = try(local.device_config[each.value.name].mpls_ldp.neighbor_dual_stack_transport_connection_max_wait, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_dual_stack_transport_connection_max_wait, null)
   neighbor_dual_stack_tlv_compliance                       = try(local.device_config[each.value.name].mpls_ldp.neighbor_dual_stack_tlv_compliance, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_dual_stack_tlv_compliance, null)
-  neighbor_password_encrypted                              = try(local.device_config[each.value.name].mpls_ldp.neighbor_password_encrypted, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_password_encrypted, null)
+  neighbor_password_encrypted                              = try(local.device_config[each.value.name].mpls_ldp.neighbor_password, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbor_password, null)
   neighbors = try(length(local.device_config[each.value.name].mpls_ldp.neighbors) == 0, true) ? null : [for neighbor in local.device_config[each.value.name].mpls_ldp.neighbors : {
     neighbor_address   = try(neighbor.address, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbors.address, null)
     label_space_id     = try(neighbor.label_space_id, local.defaults.iosxr.devices.configuration.mpls_ldp.neighbors.label_space_id, null)

--- a/iosxr_policy_map.tf
+++ b/iosxr_policy_map.tf
@@ -52,6 +52,7 @@ locals {
           police_violate_action_transmit                         = try(class.police_violate_action_transmit, local.defaults.iosxr.devices.configuration.policy_maps.classes.police_violate_action_transmit, null)
           priority_level                                         = try(class.priority_level, local.defaults.iosxr.devices.configuration.policy_maps.classes.priority_level, null)
           random_detect_default                                  = try(class.random_detect_default, local.defaults.iosxr.devices.configuration.policy_maps.classes.random_detect_default, null)
+          random_detect_ecn                                      = try(class.random_detect_ecn, local.defaults.iosxr.devices.configuration.policy_maps.classes.random_detect_ecn, null)
           service_policy_name                                    = try(class.service_policy_name, local.defaults.iosxr.devices.configuration.policy_maps.classes.service_policy_name, null)
           set_cos                                                = try(class.set_cos, local.defaults.iosxr.devices.configuration.policy_maps.classes.set_cos, null)
           set_discard_class                                      = try(class.set_discard_class, local.defaults.iosxr.devices.configuration.policy_maps.classes.set_discard_class, null)

--- a/iosxr_router_isis_address_family.tf
+++ b/iosxr_router_isis_address_family.tf
@@ -10,6 +10,9 @@ locals {
         saf_name                                                        = "unicast"
         advertise_link_attributes                                       = try(isis_process.address_family.ipv4_unicast.advertise_link_attributes, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.advertise_link_attributes, null)
         advertise_passive_only                                          = try(isis_process.address_family.ipv4_unicast.advertise_passive_only, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.advertise_passive_only, null)
+        apply_weight_ecmp_only                                          = contains(["ecmp-only", "ecmp-only-bandwidth"], try(isis_process.address_family.ipv4_unicast.apply_weight, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.apply_weight, "")) ? true : null
+        apply_weight_ecmp_only_bandwidth                                = try(isis_process.address_family.ipv4_unicast.apply_weight, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.apply_weight, null) == "ecmp-only-bandwidth" ? true : null
+        apply_weight_ucmp_only                                          = try(isis_process.address_family.ipv4_unicast.apply_weight, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.apply_weight, null) == "ucmp-only" ? true : null
         default_information_originate                                   = try(isis_process.address_family.ipv4_unicast.default_information_originate, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.default_information_originate, null)
         default_information_originate_route_policy                      = try(isis_process.address_family.ipv4_unicast.default_information_originate_route_policy, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.default_information_originate_route_policy, null)
         fast_reroute_delay_interval                                     = try(isis_process.address_family.ipv4_unicast.fast_reroute_delay_interval, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv4_unicast.fast_reroute_delay_interval, null)
@@ -302,6 +305,9 @@ resource "iosxr_router_isis_address_family" "ipv4_unicast" {
   saf_name                                                           = each.value.saf_name
   advertise_link_attributes                                          = each.value.advertise_link_attributes
   advertise_passive_only                                             = each.value.advertise_passive_only
+  apply_weight_ecmp_only                                             = each.value.apply_weight_ecmp_only
+  apply_weight_ecmp_only_bandwidth                                   = each.value.apply_weight_ecmp_only_bandwidth
+  apply_weight_ucmp_only                                             = each.value.apply_weight_ucmp_only
   default_information_originate                                      = each.value.default_information_originate
   default_information_originate_route_policy                         = each.value.default_information_originate_route_policy
   fast_reroute_delay_interval                                        = each.value.fast_reroute_delay_interval
@@ -444,6 +450,9 @@ locals {
         saf_name                                                        = "unicast"
         advertise_link_attributes                                       = try(isis_process.address_family.ipv6_unicast.advertise_link_attributes, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.advertise_link_attributes, null)
         advertise_passive_only                                          = try(isis_process.address_family.ipv6_unicast.advertise_passive_only, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.advertise_passive_only, null)
+        apply_weight_ecmp_only                                          = contains(["ecmp-only", "ecmp-only-bandwidth"], try(isis_process.address_family.ipv6_unicast.apply_weight, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.apply_weight, "")) ? true : null
+        apply_weight_ecmp_only_bandwidth                                = try(isis_process.address_family.ipv6_unicast.apply_weight, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.apply_weight, null) == "ecmp-only-bandwidth" ? true : null
+        apply_weight_ucmp_only                                          = try(isis_process.address_family.ipv6_unicast.apply_weight, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.apply_weight, null) == "ucmp-only" ? true : null
         default_information_originate                                   = try(isis_process.address_family.ipv6_unicast.default_information_originate, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.default_information_originate, null)
         default_information_originate_route_policy                      = try(isis_process.address_family.ipv6_unicast.default_information_originate_route_policy, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.default_information_originate_route_policy, null)
         fast_reroute_delay_interval                                     = try(isis_process.address_family.ipv6_unicast.fast_reroute_delay_interval, local.defaults.iosxr.devices.configuration.routing.isis_processes.address_family.ipv6_unicast.fast_reroute_delay_interval, null)
@@ -736,6 +745,9 @@ resource "iosxr_router_isis_address_family" "ipv6_unicast" {
   saf_name                                                           = each.value.saf_name
   advertise_link_attributes                                          = each.value.advertise_link_attributes
   advertise_passive_only                                             = each.value.advertise_passive_only
+  apply_weight_ecmp_only                                             = each.value.apply_weight_ecmp_only
+  apply_weight_ecmp_only_bandwidth                                   = each.value.apply_weight_ecmp_only_bandwidth
+  apply_weight_ucmp_only                                             = each.value.apply_weight_ucmp_only
   default_information_originate                                      = each.value.default_information_originate
   default_information_originate_route_policy                         = each.value.default_information_originate_route_policy
   fast_reroute_delay_interval                                        = each.value.fast_reroute_delay_interval

--- a/main.tf
+++ b/main.tf
@@ -164,6 +164,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_ftp.ftp,
     iosxr_gnmi.gnmi,
     iosxr_hostname.hostname,
+    iosxr_http_client.http_client,
     iosxr_interface_bundle_ether.bundle_ether,
     iosxr_interface_bundle_ether_subinterface.bundle_ether_subinterface,
     iosxr_interface_bvi.bvi,

--- a/main.tf
+++ b/main.tf
@@ -190,7 +190,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_lldp.lldp,
     iosxr_linux_networking.linux_networking,
     iosxr_logging.logging,
-    iosxr_logging_link_status.logging_link_status,
+    iosxr_logging_events_link_status.logging_events_link_status,
     iosxr_logging_vrf.logging_vrf,
     iosxr_monitor_session.monitor_session,
     iosxr_mpls_ldp.mpls_ldp,

--- a/main.tf
+++ b/main.tf
@@ -190,6 +190,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_lldp.lldp,
     iosxr_linux_networking.linux_networking,
     iosxr_logging.logging,
+    iosxr_logging_link_status.logging_link_status,
     iosxr_logging_vrf.logging_vrf,
     iosxr_monitor_session.monitor_session,
     iosxr_mpls_ldp.mpls_ldp,

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,7 @@ resource "iosxr_cli" "cli_0" {
     iosxr_cdp.cdp,
     iosxr_class_map_qos.class_map_qos,
     iosxr_class_map_traffic.class_map_traffic,
+    iosxr_clock.clock,
     iosxr_community_set.community_set,
     iosxr_control_plane.control_plane,
     iosxr_domain.domain,


### PR DESCRIPTION
## Proposed Changes

Terraform modules and main.tf wiring for IOS-XR features requiring provider **0.7.2**.

### `clock`
Adds the clock feature.

- `iosxr_clock.tf` — Terraform module for clock timezone configuration
- `main.tf` — added depends_on entry for `iosxr_clock`

### `logging_events_link_status`
Maps the `logging.events.link_status` field (`software-interfaces` | `disable`) to the `iosxr_logging_events_link_status` provider resource.

- `iosxr_logging_events_link_status.tf` — Terraform module for logging events link status
- `main.tf` — added depends_on entry for `iosxr_logging_events_link_status`

### `mpls_ldp` — `neighbor_password_encrypted`
Adds the global neighbor password attribute to the existing `iosxr_mpls_ldp` resource module.

- `iosxr_mpls_ldp.tf` — added `neighbor_password_encrypted`

### `http_client`
Adds the `http_client` feature.

- `iosxr_http_client.tf` — Terraform module for HTTP client configuration
- `main.tf` — added depends_on entry for `iosxr_http_client`

### `policy_map_qos` — `random_detect_ecn`
Adds the ECN-based WRED attribute to the existing `iosxr_policy_map_qos` module.

- `iosxr_policy_map.tf` — added `random_detect_ecn` mapped from NAC field `random_detect_ecn`

### `router_isis_address_family` — `apply_weight`
Adds ECMP/UCMP weight balancing mode to the existing `iosxr_router_isis_address_family` module for IPv4 and IPv6 unicast.

- `iosxr_router_isis_address_family.tf` — added `apply_weight_ecmp_only`, `apply_weight_ecmp_only_bandwidth`, and `apply_weight_ucmp_only` to ipv4/ipv6 unicast.

### `interfaces` — `macsec` (bundle-ether and subinterface)
Add MACsec attributes to the existing `iosxr_interface_bundle_ether` and `iosxr_interface_bundle_ether_subinterface` modules.

- `iosxr_interface.tf` — added `macsec_psk_keychain_name`, `macsec_fallback_psk_keychain`, `macsec_policy`, `macsec_eap_policy` to bundle-ether and bundle-ether subinterface.

> **Note:** Requires `iosxr` provider version **0.7.2** or later.

## Related Issue(s)

<!-- Link if user provides an issue number; otherwise leave empty -->

## Cisco IOS-XR Version

**Device(s) tested on:**

- [x] XRv9K    - IOS-XR version: 24.4.2
- [x] NCS5xxx  - IOS-XR version: 24.4.2
- [x] C8000    - IOS-XR version: 24.4.2

## Checklist

- [x] Latest commit is rebased from main/master with merge conflicts resolved
- [x] All pre-commit hooks passed


